### PR TITLE
onbeforeremove w/ m.route

### DIFF
--- a/src/midux.js
+++ b/src/midux.js
@@ -101,6 +101,11 @@ export const connectStore = (store) => {
 
       this.trySubscribe()
     },
+    
+    onbeforeremove(vnode) {
+      if (typeof component.onbeforeremove === "function")
+        return component.onbeforeremove(vnode)
+    },
 
     onremove(vnode) {
       this.actions = null


### PR DESCRIPTION
Added onbeforeremove, otherwise midux connected components do not trigger onbeforeremove lifecycle handlers with m.route

Given the example wrap either components A/B with midux, and note that their onbeforeremove handlers are no longer called when navigating to the other route.
https://codepen.io/ItsLeeOwen/pen/jawwWv/?editors=0010